### PR TITLE
Add component level accessibility setting

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -39,6 +39,7 @@ export default class ModalDropdown extends Component {
     defaultIndex: PropTypes.number,
     defaultValue: PropTypes.string,
     options: PropTypes.array,
+    accessible: PropTypes.boolean,
 
     style: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),
     textStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),
@@ -63,6 +64,7 @@ export default class ModalDropdown extends Component {
 
     this.state = {
       disabled: props.disabled,
+      accessible: props.accessible,
       loading: props.options == null,
       showDropdown: false,
       buttonText: props.defaultValue,
@@ -175,7 +177,7 @@ export default class ModalDropdown extends Component {
         <Modal animationType='fade'
                transparent={true}
                onRequestClose={this._onRequestClose.bind(this)}>
-          <TouchableWithoutFeedback onPress={this._onModalPress.bind(this)}>
+          <TouchableWithoutFeedback accessible={this.props.accessible} onPress={this._onModalPress.bind(this)}>
             <View style={styles.modal}>
               <View style={[styles.dropdown, this.props.dropdownStyle, frameStyle]}>
                 {this.state.loading ? this._renderLoading() : this._renderDropdown()}

--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -146,6 +146,7 @@ export default class ModalDropdown extends Component {
     return (
       <TouchableOpacity ref={button => this._button = button}
                         disabled={this.props.disabled}
+                        accessible={this.props.accessible}
                         onPress={this._onButtonPress.bind(this)}>
         {
           this.props.children ||
@@ -272,6 +273,7 @@ export default class ModalDropdown extends Component {
       this.props.renderRow(rowData, rowID, highlighted);
     let preservedProps = {
       key: key,
+      accessible: this.props.accessible,
       onPress: () => this._onRowPress(rowData, sectionID, rowID, highlightRow),
     };
     if (TOUCHABLE_ELEMENTS.find(name => name == row.type.displayName)) {

--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -39,8 +39,7 @@ export default class ModalDropdown extends Component {
     defaultIndex: PropTypes.number,
     defaultValue: PropTypes.string,
     options: PropTypes.array,
-    accessible: PropTypes.boolean,
-
+    accessible: PropTypes.bool,
     style: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),
     textStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),
     dropdownStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),


### PR DESCRIPTION
In order to enable appium and XCUItest to select react native elements by TestID, touchables need their accessible setting set to `false` (it is by default `true`, see https://github.com/facebook/react-native/pull/8243) This PR enables the prop `accessible` to be passed to the top level of the modal dropdown in order to blanket set accessibility of the touchables.