### PR TITLE
option to replace button text with a custom component

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -157,6 +157,10 @@ export default class ModalDropdown extends Component {
                         accessible={this.props.accessible}
                         onPress={this._onButtonPress.bind(this)}>
         {
+          this.props.dropdownIcon
+          ?
+          this.props.dropdownIcon
+          :
           this.props.children ||
           (
             <View style={styles.button}>


### PR DESCRIPTION
I thought this might be a nice customisation for something like a toolbar. It's a really nice modal dropdown, having the button be an overflow icon instead of the text value can be useful. It is for me! All we need to do is override onSelect to add custom actions when clicking an option.