### PR TITLE
Fixed Dropdown height for small lists

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -385,7 +385,7 @@ const styles = StyleSheet.create({
   },
   dropdown: {
     position: 'absolute',
-    height: (33 + StyleSheet.hairlineWidth) * 5,
+    maxHeight: (33 + StyleSheet.hairlineWidth) * 5,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'lightgray',
     borderRadius: 2,


### PR DESCRIPTION
By using a fixed `height` for the Dropdown module, you get an ugly list when the number of items is small, since the end of the list is empty.
This is what I'm talking about:
![photo_2017-05-19_14-56-36](https://cloud.githubusercontent.com/assets/5062458/26244183/fbfc9562-3ca3-11e7-89b0-f91b199e88d2.jpg)

By changing `height` to `maxHeight`, RN can easily reduce the size if the list is too small.
And you get this:
![photo_2017-05-19_14-56-37](https://cloud.githubusercontent.com/assets/5062458/26244311/68c73d46-3ca4-11e7-9f4d-7599ba7e051e.jpg)

