### PR TITLE
Revert "Fixed Dropdown height for small lists"

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -385,7 +385,7 @@ const styles = StyleSheet.create({
   },
   dropdown: {
     position: 'absolute',
-    maxHeight: (33 + StyleSheet.hairlineWidth) * 5,
+    height: (33 + StyleSheet.hairlineWidth) * 5,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'lightgray',
     borderRadius: 2,


### PR DESCRIPTION
Reverts sohobloo/react-native-modal-dropdown#58

@farzadab
 Sorry, this change affects the calculation of the dropdown position and makes the custom height style invalid. So I have to revert it.
In fact you can give `maxHeight` by `dropdownStyle`.