### PR TITLE
Fix keyboardShouldPersistTaps prop to support valid enum

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -35,7 +35,7 @@ export default class ModalDropdown extends Component {
     accessible: PropTypes.bool,
     animated: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,
-    keyboardShouldPersistTaps: PropTypes.string,
+    keyboardShouldPersistTaps: PropTypes.oneOf(['always', 'never', 'handled', false, true]),
 
     style: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),
     textStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),


### PR DESCRIPTION
In recent changes you've exposed the *keyboardShouldPersistTaps*
Readme says it's enum `enum('always', 'never', 'handled', false, true)`
but you're restricting it to [string only here](https://github.com/sohobloo/react-native-modal-dropdown/blob/master/components/ModalDropdown.js#L38). This should prbably be changed to support all valid values until RN removes deprecated boolean support.