### PR TITLE
Add PropType 'object' to options

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -31,7 +31,7 @@ export default class ModalDropdown extends Component {
     disabled: PropTypes.bool,
     defaultIndex: PropTypes.number,
     defaultValue: PropTypes.string,
-    options: PropTypes.array,
+    options: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 
     accessible: PropTypes.bool,
     animated: PropTypes.bool,


### PR DESCRIPTION
Currently only accept `array`. but some examples are use `object`
So i add `object` of PropTypes