### PR TITLE
Fixing the [Object object] issue with renderButtonText

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -104,7 +104,9 @@ export default class ModalDropdown extends Component {
 
     if (selectedIndex < 0) {
       selectedIndex = defaultIndex;
-      buttonText = defaultValue;
+      if (selectedIndex < 0) {
+        buttonText = defaultValue;
+      }
     }
 
     this._nextValue = null;

--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -90,17 +90,29 @@ export default class ModalDropdown extends Component {
 
   componentWillReceiveProps(nextProps) {
     let {buttonText, selectedIndex} = this.state;
-    const {defaultIndex, defaultValue, options} = nextProps;
-    buttonText = this._nextValue == null ? buttonText : this._nextValue.toString();
+    const {defaultIndex, defaultValue, options, renderButtonText} = nextProps;
+
+    console.log('##START', buttonText, defaultValue)
+
+    buttonText = this._nextValue == null ? buttonText : this._nextValue;
+
+    if (renderButtonText) {
+      buttonText = renderButtonText(buttonText) ? renderButtonText(buttonText) : buttonText;
+    } else {
+      buttonText = typeof buttonText === 'string' ? buttonText : buttonText.toString();
+    }
+
     selectedIndex = this._nextIndex == null ? selectedIndex : this._nextIndex;
+
     if (selectedIndex < 0) {
       selectedIndex = defaultIndex;
-      if (selectedIndex < 0) {
-        buttonText = defaultValue;
-      }
+      buttonText = defaultValue;
     }
+
     this._nextValue = null;
     this._nextIndex = null;
+
+    console.log('##END', buttonText, selectedIndex)
 
     this.setState({
       loading: !options,

--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -92,8 +92,6 @@ export default class ModalDropdown extends Component {
     let {buttonText, selectedIndex} = this.state;
     const {defaultIndex, defaultValue, options, renderButtonText} = nextProps;
 
-    console.log('##START', buttonText, defaultValue)
-
     buttonText = this._nextValue == null ? buttonText : this._nextValue;
 
     if (renderButtonText) {
@@ -111,8 +109,6 @@ export default class ModalDropdown extends Component {
 
     this._nextValue = null;
     this._nextIndex = null;
-
-    console.log('##END', buttonText, selectedIndex)
 
     this.setState({
       loading: !options,


### PR DESCRIPTION
Issue is here: https://github.com/sohobloo/react-native-modal-dropdown/issues/139

Essentially was a problem in the `componentWillReceiveProps` that did not account for a `renderButtonText` prop.