### PR TITLE
Feature/support web

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -18,10 +18,10 @@ import {
   TouchableNativeFeedback,
   TouchableOpacity,
   TouchableHighlight,
-  Modal,
   ActivityIndicator,
 } from 'react-native';
 
+import Modal from './modal';
 import PropTypes from 'prop-types';
 
 const TOUCHABLE_ELEMENTS = [
@@ -421,7 +421,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center'
   },
   list: {
-    //flexGrow: 1,
+    width: '100%'
   },
   rowText: {
     paddingHorizontal: 6,

--- a/components/modal.js
+++ b/components/modal.js
@@ -1,0 +1,3 @@
+import { Modal } from 'react-native';
+
+export default Modal;

--- a/components/modal.js
+++ b/components/modal.js
@@ -1,3 +1,3 @@
-import { Modal } from 'react-native';
+import Modal from 'react-native-web-modal';
 
 export default Modal;

--- a/components/modal.web.js
+++ b/components/modal.web.js
@@ -1,3 +1,0 @@
-import Modal from 'react-native-web-modal';
-
-export default Modal;

--- a/components/modal.web.js
+++ b/components/modal.web.js
@@ -1,0 +1,3 @@
+import Modal from 'react-native-web-modal';
+
+export default Modal;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "url": "https://github.com/sohobloo/react-native-modal-dropdown.git"
   },
   "dependencies": {
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "react-native-web-modal": "^1.0.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Because `react-native-web-modal` already imports the correct model impl per platform, we did not need to have the same logic duplicated in this module.