### PR TITLE
Fix displaying defaultValue and defaultIndex when data was async provided

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -94,10 +94,10 @@ export default class ModalDropdown extends Component {
     buttonText = this._nextValue == null ? buttonText : this._nextValue;
     selectedIndex = this._nextIndex == null ? selectedIndex : this._nextIndex;
     if (selectedIndex < 0) {
-      selectedIndex = defaultIndex;
-      if (selectedIndex < 0) {
-        buttonText = defaultValue;
-      }
+        if (defaultValue) {
+          buttonText = defaultValue;
+        }
+        selectedIndex = defaultIndex;
     }
     this._nextValue = null;
     this._nextIndex = null;


### PR DESCRIPTION
@sohobloo 
This PR will resolves issues like #181.
As you wrote, "If the displayed value is one of the options of the dropdown, you can call select(idx) of your dropdown reference. If not, you have to give a defaultValue and select(-1)".

After this changes, there will be no need to do things like manually call select(id) in order to set a default Value to dropdown.