### PR TITLE
dropdown style to inherit width from style if not set explicitly set …

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -245,10 +245,19 @@ export default class ModalDropdown extends Component {
     };
 
     if (showInLeft) {
+      const dropdownStyleWidth = dropdownStyle && StyleSheet.flatten(dropdownStyle).width;    
       positionStyle.left = this._buttonFrame.x;
+      positionStyle.width = dropdownStyleWidth || this._buttonFrame.w;
     } else {
-      const dropdownWidth = (dropdownStyle && StyleSheet.flatten(dropdownStyle).width) ||
-        (style && StyleSheet.flatten(style).width) || -1;
+      const dropdownStyleWidth = dropdownStyle && StyleSheet.flatten(dropdownStyle).width;
+      let styleWidth = style && StyleSheet.flatten(style).width;
+
+      if(!dropdownStyleWidth && typeof styleWidth === 'string' && styleWidth.includes('%')){
+        styleWidth = this._buttonFrame.w; 
+      }
+
+      const dropdownWidth = dropdownStyleWidth || styleWidth || -1;
+      
       if (dropdownWidth !== -1) {
         positionStyle.width = dropdownWidth;
       }


### PR DESCRIPTION
…and line up correctly if percentage width is set

This allows one to set percentage width with style prop and have dropdown modal will line up with the button component by default whether it's on the right or left side. If width is set on dropdownStyle this will override the default.  