### PR TITLE
Removed module.exports from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,4 @@
 
 import ModalDropdown from './components/ModalDropdown';
 export default ModalDropdown;
-module.exports = ModalDropdown;
+


### PR DESCRIPTION
Removed module.exports from index.js as it conflicts with babel.  A file may not contain both import/export and module.exports