### PR TITLE
Acknowledge ListView deprecation

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -13,7 +13,6 @@ import {
   Dimensions,
   View,
   Text,
-  ListView,
   TouchableWithoutFeedback,
   TouchableNativeFeedback,
   TouchableOpacity,
@@ -21,6 +20,8 @@ import {
   Modal,
   ActivityIndicator,
 } from 'react-native';
+
+import ListView from 'deprecated-react-native-listview';
 
 import PropTypes from 'prop-types';
 

--- a/example/ModalDropdown.js
+++ b/example/ModalDropdown.js
@@ -13,7 +13,6 @@ import {
   Dimensions,
   View,
   Text,
-  ListView,
   TouchableWithoutFeedback,
   TouchableNativeFeedback,
   TouchableOpacity,
@@ -21,6 +20,8 @@ import {
   Modal,
   ActivityIndicator,
 } from 'react-native';
+
+import ListView from 'deprecated-react-native-listview';
 
 import PropTypes from 'prop-types';
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/sohobloo/react-native-modal-dropdown.git"
   },
   "dependencies": {
+    "deprecated-react-native-listview": "^0.0.5",
     "prop-types": "^15.6.0"
   },
   "scripts": {


### PR DESCRIPTION
RN@0.60 has deprecated `ListView`. 

This PR migrates existing `ListViews` to use the `deprecated-react-native-listview` package. This will handle the deprecation until a more permanent solution can be put in place (migration to `FlatList`).