### PR TITLE
Update ModalDropdown.js

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -241,7 +241,7 @@ export default class ModalDropdown extends Component {
 
     const positionStyle = {
       height: dropdownHeight,
-      top: showInBottom ? this._buttonFrame.y + this._buttonFrame.h : Math.max(0, this._buttonFrame.y - dropdownHeight),
+      top: !showInBottom ? this._buttonFrame.y + this._buttonFrame.h : Math.max(0, this._buttonFrame.y - dropdownHeight),
     };
 
     if (showInLeft) {


### PR DESCRIPTION
The top value is not valid value which is return is NAN.
Error:
Invariant Violation: [757,"RCTView",91,{"position":"absolute","height":"auto","borderWidth":1,"borderColor":4291022286,"borderRadius":2,"backgroundColor":4294967295,"justifyContent":"center","borderTopWidth":0,"width":372.6,"marginTop":17.92,"shadowColor":4278190080,"shadowOffset":{"width":0,"height":2},"shadowOpacity":0.25,"shadowRadius":3.84,"elevation":5,"top":"<<NaN>>","left":33}] is not usable as a native method argument