### PR TITLE
Fix dropdown items not display issue when dropdown render at bottom in android

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -19,6 +19,7 @@ import {
   TouchableHighlight,
   Modal,
   ActivityIndicator,
+  Platform,
 } from 'react-native';
 
 import ListView from "deprecated-react-native-listview";
@@ -57,7 +58,8 @@ export default class ModalDropdown extends Component {
 
     onDropdownWillShow: PropTypes.func,
     onDropdownWillHide: PropTypes.func,
-    onSelect: PropTypes.func
+    onSelect: PropTypes.func,
+    androidWindowHeight: PropTypes.number,
   };
 
   static defaultProps = {
@@ -68,7 +70,8 @@ export default class ModalDropdown extends Component {
     options: null,
     animated: true,
     showsVerticalScrollIndicator: true,
-    keyboardShouldPersistTaps: 'never'
+    keyboardShouldPersistTaps: 'never',
+    androidWindowHeight: 0,
   };
 
   constructor(props) {
@@ -225,11 +228,11 @@ export default class ModalDropdown extends Component {
   }
 
   _calcPosition() {
-    const {dropdownStyle, style, adjustFrame} = this.props;
+    const {dropdownStyle, style, adjustFrame, androidWindowHeight} = this.props;
 
     const dimensions = Dimensions.get('window');
     const windowWidth = dimensions.width;
-    const windowHeight = dimensions.height;
+    const windowHeight = Platform.OS === 'android' ? androidWindowHeight : dimensions.height;
 
     const dropdownHeight = (dropdownStyle && StyleSheet.flatten(dropdownStyle).height) ||
       StyleSheet.flatten(styles.dropdown).height;

--- a/components/ModalDropdownWrapper.js
+++ b/components/ModalDropdownWrapper.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import {useSafeAreaFrame} from 'react-native-safe-area-context';
+import ModalDropdown from './ModalDropdown';
+
+const ModalDropdownWrapper = (props) => {
+    const frame = useSafeAreaFrame();
+
+    return <ModalDropdown androidWindowHeight={frame.height} {...props} />
+}
+
+export default ModalDropdownWrapper;

--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,3 @@
+import ModalDropdown from "./ModalDropdownWrapper";
+
+export default ModalDropdown;

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "url": "https://github.com/sohobloo/react-native-modal-dropdown.git"
   },
   "dependencies": {
+    "deprecated-react-native-listview": "0.0.5",
     "prop-types": "^15.6.0",
-    "deprecated-react-native-listview": "0.0.5"
+    "react-native-safe-area-context": "^4.3.1"
   },
   "scripts": {
     "test": "echo \"no test specified\" && exit 0"


### PR DESCRIPTION
Issue: Dropdown items not visible, when dropdown render at bottom in android.

- Dimensions API is not working as expected in the android device. Hence used 'react-native-safe-area-context' library.
- useSafeAreaFrame hook from 'react-native-safe-area-context' library, returns exact height for android device.
- So created a wrapper (ModalDropdownWrapper.js) around existing ModalDropdown component and passed 'androidWindowHeight' as a prop.

Before fix: 
<img width="394" alt="Before_fix_options_not_visible" src="https://user-images.githubusercontent.com/16955833/179750325-c788205c-5617-47d2-a9cc-1e137946dbe8.png">

After fix:
<img width="395" alt="After_fix_dropdown_render_at_top" src="https://user-images.githubusercontent.com/16955833/179750313-489d0485-476c-44c6-a43e-045578947ebb.png">

